### PR TITLE
ci: add Calcit type baseline validation

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -33,7 +33,6 @@ jobs:
         git diff --exit-code -- calcit.cirru
         cr calcit.cirru analyze check-types --summary-only --format json
         cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
-        cr calcit.cirru analyze deprecated --summary-only --format json
 
     - name: "run unit tests"
       run: yarn check:unit

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -27,6 +27,14 @@ jobs:
     - name: "install and compile"
       run: caps --ci && yarn install --immutable && cr calcit.cirru --check-only && cr js
 
+    - name: "validate Calcit type baseline"
+      run: |
+        cr calcit.cirru edit format
+        git diff --exit-code -- calcit.cirru
+        cr calcit.cirru analyze check-types --summary-only --format json
+        cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
+        cr calcit.cirru analyze deprecated --summary-only --format json
+
     - name: "run unit tests"
       run: yarn check:unit
 


### PR DESCRIPTION
Add check-types / weak-types / deprecated report gates plus snapshot format check to CI.