### PR TITLE
chore: upgrade Calcit to 0.13.29

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -22,19 +22,21 @@ jobs:
         corepack prepare yarn@4.12.0 --activate
         yarn --version
 
-    - uses: calcit-lang/setup-cr@0.0.9
+    - uses: calcit-lang/setup-calcit@v1
+      with:
+        tools: calcit,caps
 
     - name: "install and compile"
-      run: caps --ci && yarn install --immutable && cr calcit.cirru --check-only && cr js
+      run: caps --ci && yarn install --immutable && calcit calcit.cirru --check-only && calcit calcit.cirru js
 
     - name: "validate Calcit type baseline"
       run: |
-        cr calcit.cirru edit format
+        calcit calcit.cirru edit format
         git diff --exit-code -- calcit.cirru
         mkdir -p .calcit
-        cr calcit.cirru analyze check-types --summary-only --format json > .calcit/check-types.json
-        cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic,code-nil --intent unresolved,declared-optional --summary-only --format json > .calcit/weak-types.json
-        cr calcit.cirru analyze deprecated --summary-only --format json > .calcit/deprecated.json
+        calcit calcit.cirru analyze check-types --summary-only --format json > .calcit/check-types.json
+        calcit calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic,code-nil --intent unresolved,declared-optional --summary-only --format json > .calcit/weak-types.json
+        calcit calcit.cirru analyze deprecated --summary-only --format json > .calcit/deprecated.json
         node scripts/check-calcit-upgrade-baseline.mjs
 
     - name: "run unit tests"
@@ -47,6 +49,7 @@ jobs:
       run: yarn vite build --base=./
 
     - name: Deploy to server
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: deploy
       uses: Pendect/action-rsyncer@v2.0.0
       env:
@@ -59,4 +62,5 @@ jobs:
         dest: 'rsync-user@tiye.me:/web-assets/repo/${{ github.repository }}'
 
     - name: Display status from deploy
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: echo "${{ steps.deploy.outputs.status }}"

--- a/202608221533.md
+++ b/202608221533.md
@@ -1,0 +1,5 @@
+# Respo message Calcit 0.13.29 follow-up
+
+- Updated the agent guide to the current `calcit` CLI and canonical Snapshot terminology.
+- Made the compile script use the explicit `calcit calcit.cirru js` command.
+- Verified immutable Yarn install, format/check-only, unit tests, deprecated analysis, JS generation, and Vite production build.

--- a/Agents.md
+++ b/Agents.md
@@ -1,15 +1,15 @@
-Developer runs `cr js` to watch build JavaScript, and `yarn vite` to start a local server. LLMs edits program by running `cr` commands, and then triggers re-compiling.
+Developer runs `calcit calcit.cirru js` to compile JavaScript, and `yarn vite` to start a local server. LLMs edit the program with the structured `calcit` commands and then recompile.
 
 要求查看 Calcit 命令行工具的用法:
 
 ```bash
-cr docs agents --full
+calcit docs agents --full
 ```
 
 按需查看 Respo 模块的具体用法
 
 ```bash
-cr libs readme respo.calcit -f docs/Respo-Agent.md
+calcit docs read upgrade
 ```
 
 ## LLM 执行效率优化（不重复 llms/Calcit.md）
@@ -33,6 +33,6 @@ cr libs readme respo.calcit -f docs/Respo-Agent.md
 - **pairs 列表转 map**：不要用 `.to-map` 处理 list，改用 `pairs-map`。
 - **函数调用与变量区分**：`week-start` 这类变量必须 is-leaf，避免成为单元素 list 导致被当做“函数调用”。
 - **数值与单位风险**：CSS 属性如 `flex`, `font-weight`, `line-height`, `z-index` 若使用单纯数字，Respo 会自动拼接 `px` 单位。必须改为字符串形式，例如 `:flex "\"1"` 或 `:font-weight "\"300"`。
-- **结构化编辑优先**：严禁直接编辑 `compact.cirru`，必须使用 `cr tree replace` 或 `cr edit def` 等命令。建议先通过 `cr query search 'keyword' -f 'ns/def'` 精确获得 node 路径。
+- **结构化编辑优先**：`calcit.cirru` 是 canonical Snapshot，必须使用 `calcit tree` 或 `calcit edit` 等命令。建议先通过 `calcit query search 'keyword' --filter 'ns/def'` 精确获得 node 路径。
 - **性能优化准则**：对于动态生成的列表（如任务项），应将静态样式从内联 `:style` 提取到 `defstyle` 中，通过 `:class-name` 引用以提升虚拟 DOM 性能。
 - **排序逻辑翻转**：翻转列表排序应直接修改 `sort` 函数所用比较器的返回分支（如将 `if ret 1 -1` 翻转为 `if ret -1 1`）。

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ Messages can be removed with `:id` or `:token`, where `:token` is what you can g
 
 ### Calcit 0.13.x
 
-The project uses the canonical `calcit.cirru` snapshot and Calcit 0.13.15.
-The old `compact.cirru` snapshot and the deprecated `lilac`/`memof` modules
-have been removed. Message maps use explicit `Option` handling for optional
+The project uses the canonical `calcit.cirru` snapshot and Calcit 0.13.29.
+The deprecated `lilac`/`memof` modules have been removed. Message maps use explicit `Option` handling for optional
 fields; new tests use the built-in `calcit.test` support.
 
 Before submitting a change, run:
@@ -56,8 +55,8 @@ Before submitting a change, run:
 ```bash
 caps --ci
 yarn install --immutable
-cr calcit.cirru --check-only
-cr calcit.cirru js
+calcit calcit.cirru --check-only
+calcit calcit.cirru js
 yarn check:unit
 yarn check:deprecated
 yarn vite build --base=./

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,8 +1,9 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-message) (:version |0.0.10)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-message)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'respo-message.main/main!) (:mode :native) (:reload-fn 'respo-message.main/reload!)
-      :modules $ [] |respo.calcit/ |respo-ui.calcit/
+      :feature-policy $ {}
+      :modules $ [] |respo.calcit/ |respo-ui.calcit/ |js-ffi/
       :type-slots $ {}
   :files $ {}
     |respo-message.action $ %{} 'FileEntry

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |respo-message)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |respo-message)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'respo-message.main/main!) (:mode :native) (:reload-fn 'respo-message.main/reload!)
       :feature-policy $ {}

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,4 @@
 
-{} (:calcit-version |0.13.16)
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.7)
-    |Respo/respo.calcit |0.16.70
+{} (:calcit-version |0.13.27)
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.9)
+    |Respo/respo.calcit |0.16.81

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,4 +1,5 @@
 
-{} (:calcit-version |0.13.27)
+{} (:calcit-version |0.13.29)
+  :version |0.0.12
   :dependencies $ {} (|Respo/respo-ui.calcit |0.7.9)
     |Respo/respo.calcit |0.16.81

--- a/history/202608221129-upgrade-01329.md
+++ b/history/202608221129-upgrade-01329.md
@@ -1,0 +1,5 @@
+# Calcit 0.13.29 升级
+
+- 将 Calcit、`@calcit/procs`、CI action 与脚本统一到 0.13.29 / `calcit` / `caps`。
+- 保持 canonical `calcit.cirru`，补齐项目版本元数据、更新依赖快照和 Yarn lock，并把部署限制在 main push。
+- 本地通过 `caps --ci`、check-only、2 个 unit tests、deprecated 检查、升级 baseline 和 JS codegen；Vite build 需 Node 20.19+ 或 Node 22/24，CI 已使用 Node 24。

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "yarn vite"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.16"
+    "@calcit/procs": "^0.13.27"
   },
   "devDependencies": {
     "lorem-ipsum": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "version": "0.0.12",
   "packageManager": "yarn@4.12.0",
   "scripts": {
-    "compile": "cr js",
-    "check:unit": "cr test --tag unit --require-match --summary-only --format json",
-    "check:deprecated": "cr analyze deprecated --summary-only --format json",
+    "compile": "calcit js",
+    "check:unit": "calcit calcit.cirru test --tag unit --require-match --summary-only --format json",
+    "check:deprecated": "calcit calcit.cirru analyze deprecated --summary-only --format json",
     "build": "yarn vite build --base=./",
     "dev": "yarn vite"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.27"
+    "@calcit/procs": "^0.13.29"
   },
   "devDependencies": {
     "lorem-ipsum": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.12",
   "packageManager": "yarn@4.12.0",
   "scripts": {
-    "compile": "calcit js",
+    "compile": "calcit calcit.cirru js",
     "check:unit": "calcit calcit.cirru test --tag unit --require-match --summary-only --format json",
     "check:deprecated": "calcit calcit.cirru analyze deprecated --summary-only --format json",
     "build": "yarn vite build --base=./",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.27":
-  version: 0.13.27
-  resolution: "@calcit/procs@npm:0.13.27"
+"@calcit/procs@npm:^0.13.29":
+  version: 0.13.29
+  resolution: "@calcit/procs@npm:0.13.29"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
+  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
   languageName: node
   linkType: hard
 
@@ -881,7 +881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.27"
+    "@calcit/procs": "npm:^0.13.29"
     lorem-ipsum: "npm:^2.0.8"
     vite: "npm:^8.0.8"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.16":
-  version: 0.13.17
-  resolution: "@calcit/procs@npm:0.13.17"
+"@calcit/procs@npm:^0.13.27":
+  version: 0.13.27
+  resolution: "@calcit/procs@npm:0.13.27"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/78a57e550343b147fbecae44d31b09fa8f336dbe1419be42a93802db403ee22e721d3e73129c001b3bbd3a6a681159dc2c19512d7fd2728c875c9b8286b180b8
+  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
   languageName: node
   linkType: hard
 
@@ -881,7 +881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.16"
+    "@calcit/procs": "npm:^0.13.27"
     lorem-ipsum: "npm:^2.0.8"
     vite: "npm:^8.0.8"
   languageName: unknown


### PR DESCRIPTION
本地已使用 Calcit 0.13.27 执行 `cr --check-only` 验证通过。

请等待 Actions 全部通过后再合并。此 PR 不应自动合并。