### PR TITLE
chore: upgrade to Calcit 0.13.51

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -81,13 +81,16 @@
                         :on-click $ fn (e d!)
                           let
                               new-token $ generate-id!
-                            d! action/create $ merge schema/message
-                              {} (:token new-token)
-                                :text $ lorem-ipsum/loremIpsum
-                            js/setTimeout
-                              fn () $ d! action/remove-one
-                                {} $ :token new-token
-                              , 2000
+                            do
+                              d! action/create $ merge schema/message
+                                {} (:token new-token)
+                                  :text $ lorem-ipsum/loremIpsum
+                              js/setTimeout
+                                fn () $ do
+                                  d! action/remove-one $ {} (:token new-token)
+                                  , &unit
+                                , 2000
+                              , &unit
                       <> |Try
                     =< 16 nil
                     button

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
-{} (:calcit-version |0.13.29)
-  :version |0.0.12
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.9)
-    |Respo/respo.calcit |0.16.81
+{} (:calcit-version |0.13.51)
+  :version |0.0.13
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.11)
+    |Respo/respo.calcit |0.16.87

--- a/history/202608271730-upgrade-calcit-01351.md
+++ b/history/202608271730-upgrade-calcit-01351.md
@@ -1,0 +1,7 @@
+# Upgrade to Calcit 0.13.51
+
+- Release respo-message 0.0.13 with Respo UI 0.7.11 and Respo 0.16.87.
+- Pin the JavaScript runtime package to the matching Calcit release.
+- Validate the resolved module graph and production JavaScript bundle.
+- Make the delayed message action explicitly return `&unit` from both callback
+  boundaries, while retaining the create and delayed remove dispatches.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.12",
+  "version": "0.0.13",
   "packageManager": "yarn@4.12.0",
   "scripts": {
     "compile": "calcit calcit.cirru js",
@@ -9,7 +9,7 @@
     "dev": "yarn vite"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.29"
+    "@calcit/procs": "0.13.51"
   },
   "devDependencies": {
     "lorem-ipsum": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.29":
-  version: 0.13.29
-  resolution: "@calcit/procs@npm:0.13.29"
+"@calcit/procs@npm:0.13.51":
+  version: 0.13.51
+  resolution: "@calcit/procs@npm:0.13.51"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
+  checksum: 10c0/a83022d613374aac8e648ff9213a011d18ffe204607fece9ba9d7bccbc022e09eb028dbb74589a3c2a7c5aeeb76eb368f058d08d072b9ca4ad45fc4693cdfa00
   languageName: node
   linkType: hard
 
@@ -881,7 +881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.29"
+    "@calcit/procs": "npm:0.13.51"
     lorem-ipsum: "npm:^2.0.8"
     vite: "npm:^8.0.8"
   languageName: unknown


### PR DESCRIPTION
## Summary
- release respo-message 0.0.13 on Calcit 0.13.51 with Respo UI 0.7.11 and Respo 0.16.87
- pin `@calcit/procs` to the compiler version
- make the delayed-message UI callbacks explicitly return `&unit` while preserving their create/remove behavior

## Validation
- `caps --ci`
- `calcit calcit.cirru edit format`
- `calcit calcit.cirru --check-only`
- `calcit calcit.cirru analyze check-types --deps --summary-only --format json` (`legacy_macro_schemas: 0`)
- `yarn check:unit` (2/2)
- `yarn check:deprecated`
- `calcit calcit.cirru js && yarn build`
- `YARN_NPM_REGISTRY_SERVER=https://registry.npmjs.org yarn install --immutable`