### PR TITLE
chore: upgrade Calcit 0.13.64 / 升级 Calcit 0.13.64

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
-{} (:calcit-version |0.13.63)
+{} (:calcit-version |0.13.64)
   :version |0.0.15
   :dependencies $ {} (|Respo/respo-ui.calcit |0.7.12)
     |Respo/respo.calcit |0.16.87

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "yarn vite"
   },
   "dependencies": {
-    "@calcit/procs": "0.13.63"
+    "@calcit/procs": "0.13.64"
   },
   "devDependencies": {
     "lorem-ipsum": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:0.13.63":
-  version: 0.13.63
-  resolution: "@calcit/procs@npm:0.13.63"
+"@calcit/procs@npm:0.13.64":
+  version: 0.13.64
+  resolution: "@calcit/procs@npm:0.13.64"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/43901565386563bd04b5ecfaa05339035e5434e879a8aa733e08632d2003eacb8f90d484b42f26a6f73a8b4500ad455f6f4fc8df836f36666b073ca913d50989
+  checksum: 10c0/df308fc6682ee7f3c07aa03ae2c68eb88af6e4206b51aba652c90c4a2e53638e2396258a123a6015dd6bbd70d2958cfc9c1947561049d43227c7979ed87722c0
   languageName: node
   linkType: hard
 
@@ -881,7 +881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:0.13.63"
+    "@calcit/procs": "npm:0.13.64"
     lorem-ipsum: "npm:^2.0.8"
     vite: "npm:^8.0.8"
   languageName: unknown


### PR DESCRIPTION
## English

Upgrades the Calcit CLI and `@calcit/procs` lockstep version from 0.13.63 to 0.13.64.

Validation completed:

- `caps verify --toolchain`
- `caps --strict --ci`
- `calcit calcit.cirru --check-only`
- `calcit calcit.cirru js`
- `yarn install --immutable`

## 中文

将 Calcit CLI 与 `@calcit/procs` 从 0.13.63 同步升级至 0.13.64。

已完成严格依赖校验、类型检查、JS 生成和不可变 Yarn 安装验证。