### PR TITLE
Align Respo UI 0.7.13 / 对齐 Respo UI 0.7.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
-Respo Message for calcit-js
-----
+## Respo Message for Calcit
 
 > Message component for Respo apps.
 
@@ -46,14 +45,15 @@ Messages can be removed with `:id` or `:token`, where `:token` is what you can g
 
 ### Calcit 0.13.x
 
-The project uses the canonical `calcit.cirru` snapshot and Calcit 0.13.29.
+The project uses the canonical `calcit.cirru` snapshot and Calcit 0.13.64.
 The deprecated `lilac`/`memof` modules have been removed. Message maps use explicit `Option` handling for optional
 fields; new tests use the built-in `calcit.test` support.
 
 Before submitting a change, run:
 
 ```bash
-caps --ci
+caps --ci --strict
+caps verify --toolchain
 yarn install --immutable
 calcit calcit.cirru --check-only
 calcit calcit.cirru js
@@ -81,3 +81,9 @@ defn dispatch! (op op-data)
 ### License
 
 MIT
+
+### 中文说明
+
+本模块为 Calcit/Respo 应用提供消息组件及对应 updater。项目使用 canonical
+`calcit.cirru`，Calcit 与 `@calcit/procs` 保持 0.13.64 lockstep，并固定
+到已发布的 Respo UI tag。

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
 {} (:calcit-version |0.13.64)
   :version |0.0.15
-  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.12)
+  :dependencies $ {} (|Respo/respo-ui.calcit |0.7.13)
     |Respo/respo.calcit |0.16.87

--- a/history/202608301530-align-respo-ui-0713.md
+++ b/history/202608301530-align-respo-ui-0713.md
@@ -1,0 +1,6 @@
+# 2026-08-30 Align Respo UI 0.7.13 / 对齐 Respo UI 0.7.13
+
+- Align the module dependency with the released Respo UI 0.7.13 chain.
+- Refresh the README for Calcit 0.13.64 and strict toolchain verification.
+- 将模块依赖对齐到已发布的 Respo UI 0.7.13 依赖链。
+- 更新 README 中的 Calcit 0.13.64 与严格工具链验证说明。


### PR DESCRIPTION
## Summary / 概要

- align the module with released Respo UI 0.7.13
- refresh Calcit 0.13.64 and strict toolchain documentation
- remove the historical calcit-js framing from the project title
- 将模块对齐到已发布的 Respo UI 0.7.13
- 更新 Calcit 0.13.64 与严格工具链说明
- 从项目标题移除历史 calcit-js 定位

## Validation / 验证

- strict Caps dependency resolution and toolchain verification
- canonical Snapshot and check-only
- migration baseline with deprecated calls at zero
- 2/2 unit tests
- Calcit JS codegen
- Node 24 Vite production build
